### PR TITLE
Fix local storage to work on Chrome

### DIFF
--- a/components/addGame/AddGame.tsx
+++ b/components/addGame/AddGame.tsx
@@ -13,6 +13,7 @@ export default function AddGame() {
     e.preventDefault();
 
     const savedGames = getGames('GAMES_TO_PLAY');
+
     const updatedGames = {
       ...savedGames,
       [timeSpanOption]: [

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // reactStrictMode: false,
+  reactStrictMode: false,
 };
 
 module.exports = nextConfig;

--- a/utils/localStorage.ts
+++ b/utils/localStorage.ts
@@ -1,22 +1,17 @@
 import { GamesToPlay } from "./types";
 
 export function setGames(key: string, value: GamesToPlay) {
-
-  // if(typeof window !== 'undefined') {
     const stringyGames = JSON.stringify(value);
       window.localStorage.setItem(key, stringyGames);
-  // }
 };
 
 export function getGames(key: string) {
-  // if(typeof window !== 'undefined') {
     const stringyGames = window.localStorage.getItem(key);
 
     if(stringyGames) {
       const parsedGames: GamesToPlay = JSON.parse(stringyGames);
       return parsedGames
     }
-  // }
 
   return {} as GamesToPlay;
 };

--- a/utils/localStorage.ts
+++ b/utils/localStorage.ts
@@ -1,17 +1,22 @@
 import { GamesToPlay } from "./types";
 
 export function setGames(key: string, value: GamesToPlay) {
-    const stringyGames = JSON.stringify(value);
-      window.localStorage.setItem(key, stringyGames);
+  const stringyGames = JSON.stringify(value);
+  window.localStorage.setItem(key, stringyGames);  
 };
 
 export function getGames(key: string) {
-    const stringyGames = window.localStorage.getItem(key);
+  const stringyGames = window.localStorage.getItem(key);
 
-    if(stringyGames) {
-      const parsedGames: GamesToPlay = JSON.parse(stringyGames);
-      return parsedGames
-    }
+  if(stringyGames) {
+    const parsedGames: GamesToPlay = JSON.parse(stringyGames);
+    return parsedGames
+  }
 
-  return {} as GamesToPlay;
+  return {
+    week: [],
+    month: [],
+    year: []
+    
+  } as GamesToPlay;
 };


### PR DESCRIPTION
It already worked in Firefox but had to have getGames return a properly structured object if it doesn't yet exist in local storage.